### PR TITLE
Add support for rails-assets-angular gem from https://rails-assets.org/

### DIFF
--- a/angularjs-rails-cdn.gemspec
+++ b/angularjs-rails-cdn.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
     gem.cert_chain = ['gem-public_cert.pem']
   end
 
-  gem.add_dependency 'angularjs-rails'
   gem.add_dependency 'railties', '>= 3.0'
 
   gem.add_development_dependency 'bundler', '~> 1.3'

--- a/lib/angularjs-rails-cdn.rb
+++ b/lib/angularjs-rails-cdn.rb
@@ -1,10 +1,14 @@
 require 'active_support/core_ext/string/output_safety'
-require 'angularjs-rails'
 require 'angularjs-rails-cdn/version'
 
 module AngularJS::Rails::Cdn
   module ActionViewExtensions
-    ANGULARJS_VERSION = AngularJS::Rails::VERSION
+    if defined?(AngularJS::Rails::VERSION)
+        ANGULARJS_VERSION = AngularJS::Rails::VERSION
+    elsif defined?(RailsAssetsAngular::VERSION)
+      ANGULARJS_VERSION = RailsAssetsAngular::VERSION
+    end
+    
     OFFLINE = (Rails.env.development? or Rails.env.test?)
 
     URL = {


### PR DESCRIPTION
rails-assets-angular gem from https://rails-assets.org/ can now be used with cdn too. rails-assets gem is usually more up to date.

This also removes dependency to angularjs-rails, so it needs to be added to bundler _before_ angularjs-rails-cdn.
